### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/agent-mcp/sim-tee/sample_code/requirements.txt
+++ b/agent-mcp/sim-tee/sample_code/requirements.txt
@@ -9,7 +9,7 @@ pydantic~=2.11.3
 anthropic~=0.50.0
 beautifulsoup4>=4.12.2
 
-pyautogen[all]==0.9
+ag2[all]==0.9
 mcp==1.8.1
 python-dotenv==1.0.1
 openai==1.78.1

--- a/agent-mcp/sim-tee/workspace/requirements.txt
+++ b/agent-mcp/sim-tee/workspace/requirements.txt
@@ -9,7 +9,7 @@ pydantic~=2.11.3
 anthropic~=0.50.0
 beautifulsoup4>=4.12.2
 
-pyautogen[all]==0.9
+ag2[all]==0.9
 mcp==1.8.1
 python-dotenv==1.0.1
 openai==1.78.1


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
